### PR TITLE
Fix `normalize` preservation of `..` when path is not rooted

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 encoding = "2.1.0"
 
 gradle-binary-compat = "0.13.2"
-gradle-kmp-configuration = "0.1.5"
+gradle-kmp-configuration = "0.1.7"
 gradle-kotlin = "1.9.21"
 gradle-publish-maven = "0.25.3"
 

--- a/library/file/src/commonTest/kotlin/io/matthewnelson/kmp/file/NormalizeUnitTest.kt
+++ b/library/file/src/commonTest/kotlin/io/matthewnelson/kmp/file/NormalizeUnitTest.kt
@@ -35,6 +35,7 @@ class NormalizeUnitTest {
         assertEquals("path", "relative/../path".toFile().normalize().path)
         assertEquals("", "relative/../path/..".toFile().normalize().path)
         assertEquals("relative", "relative/o/./.././path/..".toFile().normalize().path)
+        assertEquals("..${s}..${s}relative", "../../relative/path/..".toFile().normalize().path)
 
         if (!IsWindows) return
 

--- a/library/file/src/nonJvmMain/kotlin/io/matthewnelson/kmp/file/File.kt
+++ b/library/file/src/nonJvmMain/kotlin/io/matthewnelson/kmp/file/File.kt
@@ -120,7 +120,7 @@ private fun Path.resolveSlashes(): Path {
         result = result.replace('/', SysPathSep)
     }
 
-    val rootSlashes = result.rootOrNull() ?: ""
+    val rootSlashes = result.rootOrNull(normalizing = false) ?: ""
 
     var lastWasSlash = rootSlashes.isNotEmpty()
     var i = rootSlashes.length


### PR DESCRIPTION
Closes #30 