### PR TITLE
Rename `open` -> `fOpen` for native

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,8 @@ fun nativeMain(f1: File, f2: File) {
     // Native specific extension functions
 
     // Use a CPointer<FILE> with auto-closure on completion
-    f1.open(flags = "rb") { file1 ->
-        f2.open(flags = "wb") { file2 ->
+    f1.fOpen(flags = "rb") { file1 ->
+        f2.fOpen(flags = "wb") { file2 ->
             val buf = ByteArray(4096)
 
             while (true) {

--- a/library/file/src/nativeMain/kotlin/io/matthewnelson/kmp/file/FileNative.kt
+++ b/library/file/src/nativeMain/kotlin/io/matthewnelson/kmp/file/FileNative.kt
@@ -44,7 +44,7 @@ import kotlin.contracts.contract
 @ExperimentalForeignApi
 @Throws(IOException::class)
 @OptIn(ExperimentalContracts::class)
-public inline fun <T: Any?> File.open(
+public inline fun <T: Any?> File.fOpen(
     flags: String,
     block: (file: CPointer<FILE>) -> T,
 ): T {

--- a/library/file/src/nativeMain/kotlin/io/matthewnelson/kmp/file/internal/NativePlatform.kt
+++ b/library/file/src/nativeMain/kotlin/io/matthewnelson/kmp/file/internal/NativePlatform.kt
@@ -24,7 +24,7 @@ import platform.posix.errno
 @Throws(IOException::class)
 @Suppress("NOTHING_TO_INLINE")
 @OptIn(DelicateFileApi::class, ExperimentalForeignApi::class)
-internal actual inline fun File.platformReadBytes(): ByteArray = open(flags = "rb") { file ->
+internal actual inline fun File.platformReadBytes(): ByteArray = fOpen(flags = "rb") { file ->
     val bufferedBytes = mutableListOf<ByteArray>()
     val buf = ByteArray(4096)
 
@@ -64,7 +64,7 @@ internal actual inline fun File.platformReadUtf8(): String = readBytes().decodeT
 @Suppress("NOTHING_TO_INLINE")
 @OptIn(DelicateFileApi::class, ExperimentalForeignApi::class)
 internal actual inline fun File.platformWriteBytes(array: ByteArray) {
-    open("wb") { file ->
+    fOpen("wb") { file ->
         var written = 0
 
         while (written < array.size) {


### PR DESCRIPTION
closes #34 