### PR TITLE
Use `Buffer.isBuffer` instead of peeking zeroith index when wrapping

### DIFF
--- a/library/file/src/jsMain/kotlin/io/matthewnelson/kmp/file/Wrappers.kt
+++ b/library/file/src/jsMain/kotlin/io/matthewnelson/kmp/file/Wrappers.kt
@@ -32,15 +32,17 @@ public value class Buffer internal constructor(
     internal val value: buffer_Buffer
 ) {
 
-    public val length: Number get() = value.length.toLong()
+    public val length: Long get() = value.length.toLong()
     public fun fill() { value.fill() }
 
+    // @Throws(IOException::class)
     public fun readInt8(index: Number): Byte = try {
         value.readInt8(index) as Byte
     } catch (t: Throwable) {
         throw t.toIOException()
     }
 
+    // @Throws(IOException::class)
     public fun toUtf8(
         start: Number = 0,
         end: Number = this.length,
@@ -56,14 +58,13 @@ public value class Buffer internal constructor(
 
     public companion object {
 
-        public fun wrap(buffer: dynamic): Buffer = try {
-            val buf = Buffer(buffer.unsafeCast<buffer_Buffer>())
-            // Attempt to read a single byte to test
-            // if it is actually a Buffer
-            buf.readInt8(0)
-            buf
-        } catch (t: Throwable) {
-            throw t.toIOException()
+        // @Throws(IOException::class)
+        public fun wrap(buffer: dynamic): Buffer {
+            if (!buffer_Buffer.isBuffer(buffer)) {
+                throw IOException("Not a buffer")
+            }
+
+            return Buffer(buffer.unsafeCast<buffer_Buffer>())
         }
     }
 }

--- a/library/file/src/jsMain/kotlin/io/matthewnelson/kmp/file/internal/JsBuffer.kt
+++ b/library/file/src/jsMain/kotlin/io/matthewnelson/kmp/file/internal/JsBuffer.kt
@@ -22,8 +22,12 @@ package io.matthewnelson.kmp.file.internal
 /** [docs](https://nodejs.org/api/buffer.html#class-buffer) */
 @JsName("Buffer")
 internal external class buffer_Buffer {
-    val length: Number
-    fun fill()
-    fun readInt8(offset: Number): Number
-    fun toString(encoding: String, start: Number, end: Number): String
+    internal val length: Number
+    internal fun fill()
+    internal fun readInt8(offset: Number): Number
+    internal fun toString(encoding: String, start: Number, end: Number): String
+
+    internal companion object {
+        internal fun isBuffer(obj: dynamic): Boolean
+    }
 }

--- a/library/file/src/jsMain/kotlin/io/matthewnelson/kmp/file/internal/JsFs.kt
+++ b/library/file/src/jsMain/kotlin/io/matthewnelson/kmp/file/internal/JsFs.kt
@@ -74,8 +74,8 @@ internal external fun fs_statSync(path: String): fs_Stats
 /** [docs](https://nodejs.org/api/fs.html#class-fsstats) */
 @JsName("Stats")
 internal external class fs_Stats {
-    val mode: Number
-    fun isFile(): Boolean
-    fun isDirectory(): Boolean
-    fun isSymbolicLink(): Boolean
+    internal val mode: Number
+    internal fun isFile(): Boolean
+    internal fun isDirectory(): Boolean
+    internal fun isSymbolicLink(): Boolean
 }

--- a/library/file/src/jsMain/kotlin/io/matthewnelson/kmp/file/internal/JsPlatform.kt
+++ b/library/file/src/jsMain/kotlin/io/matthewnelson/kmp/file/internal/JsPlatform.kt
@@ -50,7 +50,7 @@ internal actual inline fun File.platformReadBytes(): ByteArray = try {
 
     // Max buffer size for Node.js 16 can be larger than the
     // maximum size of the ByteArray capacity
-    if (buffer.length.toLong() >= Int.MAX_VALUE.toLong()) {
+    if (buffer.length >= Int.MAX_VALUE.toLong()) {
         throw IOException("File size exceeds limit of ${Int.MAX_VALUE}")
     }
 

--- a/library/file/src/jsTest/kotlin/io/matthewnelson/kmp/file/WrapperUnitTest.kt
+++ b/library/file/src/jsTest/kotlin/io/matthewnelson/kmp/file/WrapperUnitTest.kt
@@ -15,10 +15,7 @@
  **/
 package io.matthewnelson.kmp.file
 
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
-import kotlin.test.fail
+import kotlin.test.*
 
 @OptIn(DelicateFileApi::class)
 class WrapperUnitTest {
@@ -43,11 +40,13 @@ class WrapperUnitTest {
     @Test
     fun givenBuffer_whenFromDynamicAndNotActuallyABuffer_thenThrowsException() {
         val stats = FILE_LOREM_IPSUM.stat().unwrap()
-        try {
-            Buffer.wrap(stats)
-            fail()
-        } catch (_: IOException) {
-            // pass
-        }
+        assertFailsWith<IOException> { Buffer.wrap(stats) }
+    }
+
+    @Test
+    fun givenEmptyBuffer_whenToString_thenIsEmptyString() {
+        val buf = js("Buffer").alloc(0)
+        val string = Buffer.wrap(buf).toUtf8()
+        assertTrue(string.isEmpty())
     }
 }


### PR DESCRIPTION
Closes #41 