### PR TITLE
Use `inline` functions to back top-level `Sys*` variables

### DIFF
--- a/library/file/src/commonMain/kotlin/io/matthewnelson/kmp/file/KmpFile.kt
+++ b/library/file/src/commonMain/kotlin/io/matthewnelson/kmp/file/KmpFile.kt
@@ -32,13 +32,13 @@ import kotlin.jvm.JvmName
  *  - Windows: "\\"
  * */
 @JvmField
-public val SysDirSep: Char = PlatformDirSeparator
+public val SysDirSep: Char = PlatformDirSeparator()
 
 /**
  * The system's temporary directory
  * */
 @JvmField
-public val SysTempDir: File = PlatformTempDirectory
+public val SysTempDir: File = PlatformTempDirectory()
 
 @JvmName("get")
 public fun String.toFile(): File = File(this)

--- a/library/file/src/commonMain/kotlin/io/matthewnelson/kmp/file/internal/-CommonPlatform.kt
+++ b/library/file/src/commonMain/kotlin/io/matthewnelson/kmp/file/internal/-CommonPlatform.kt
@@ -24,8 +24,10 @@ import kotlin.jvm.JvmSynthetic
 
 internal typealias Path = String
 
-internal expect val PlatformDirSeparator: Char
-internal expect val PlatformTempDirectory: File
+@Suppress("NOTHING_TO_INLINE", "FunctionName")
+internal expect inline fun PlatformDirSeparator(): Char
+@Suppress("NOTHING_TO_INLINE", "FunctionName")
+internal expect inline fun PlatformTempDirectory(): File
 
 internal expect val IsWindows: Boolean
 

--- a/library/file/src/darwinMain/kotlin/io/matthewnelson/kmp/file/internal/DarwinFs.kt
+++ b/library/file/src/darwinMain/kotlin/io/matthewnelson/kmp/file/internal/DarwinFs.kt
@@ -25,13 +25,13 @@ import platform.posix.mkdir
 @Suppress("NOTHING_TO_INLINE")
 @OptIn(ExperimentalForeignApi::class)
 internal actual inline fun fs_platform_chmod(
-    path: String,
+    path: Path,
     mode: UInt,
 ): Int = chmod(path, mode.convert()).convert()
 
 @Suppress("NOTHING_TO_INLINE")
 @OptIn(ExperimentalForeignApi::class)
 internal actual inline fun fs_platform_mkdir(
-    path: String,
+    path: Path,
     mode: UInt,
 ): Int = mkdir(path, mode.convert()).convert()

--- a/library/file/src/darwinMain/kotlin/io/matthewnelson/kmp/file/internal/DarwinPlatform.kt
+++ b/library/file/src/darwinMain/kotlin/io/matthewnelson/kmp/file/internal/DarwinPlatform.kt
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
+@file:Suppress("KotlinRedundantDiagnosticSuppress")
+
 package io.matthewnelson.kmp.file.internal
 
 import io.matthewnelson.kmp.file.File
@@ -22,7 +24,8 @@ import kotlinx.cinterop.toKString
 import platform.posix.getenv
 
 @OptIn(ExperimentalForeignApi::class)
-internal actual val PlatformTempDirectory: File by lazy {
+@Suppress("NOTHING_TO_INLINE", "FunctionName")
+internal actual inline fun PlatformTempDirectory(): File {
     val tmpdir = getenv("TMPDIR")
-    (tmpdir?.toKString() ?: "/tmp").toFile()
+    return (tmpdir?.toKString() ?: "/tmp").toFile()
 }

--- a/library/file/src/jsMain/kotlin/io/matthewnelson/kmp/file/internal/JsFs.kt
+++ b/library/file/src/jsMain/kotlin/io/matthewnelson/kmp/file/internal/JsFs.kt
@@ -21,55 +21,55 @@ package io.matthewnelson.kmp.file.internal
 
 /** [docs](https://nodejs.org/api/fs.html#fschmodsyncpath-mode) */
 @JsName("chmodSync")
-internal external fun fs_chmodSync(path: String, mode: String)
+internal external fun fs_chmodSync(path: Path, mode: String)
 
 /** [docs](https://nodejs.org/api/fs.html#fsexistssyncpath) */
 @JsName("existsSync")
-internal actual external fun fs_exists(path: String): Boolean
+internal actual external fun fs_exists(path: Path): Boolean
 
 /** [docs](https://nodejs.org/api/fs.html#fsmkdirsyncpath-options) */
 @JsName("mkdirSync")
-internal external fun fs_mkdirSync(path: String, options: dynamic): String?
+internal external fun fs_mkdirSync(path: Path, options: dynamic): String?
 
 /** [docs](https://nodejs.org/api/fs.html#fsreadfilesyncpath-options) */
 @JsName("readFileSync")
-internal external fun fs_readFileSync(path: String): buffer_Buffer
+internal external fun fs_readFileSync(path: Path): buffer_Buffer
 
 /** [docs](https://nodejs.org/api/fs.html#fsrealpathsyncpath-options) */
 @JsName("realpathSync")
-internal external fun fs_realpathSync(path: String): String
+internal external fun fs_realpathSync(path: Path): String
 
 /** [docs](https://nodejs.org/api/fs.html#fsrmsyncpath-options) */
 @JsName("rmSync")
-internal external fun fs_rmSync(path: String, options: dynamic)
+internal external fun fs_rmSync(path: Path, options: dynamic)
 
 /** [docs](https://nodejs.org/api/fs.html#fsrmdirsyncpath-options) */
 @JsName("rmdirSync")
-internal external fun fs_rmdirSync(path: String, options: dynamic)
+internal external fun fs_rmdirSync(path: Path, options: dynamic)
 
 /** [docs](https://nodejs.org/api/fs.html#fsunlinksyncpath) */
 @JsName("unlinkSync")
-internal external fun fs_unlinkSync(path: String)
+internal external fun fs_unlinkSync(path: Path)
 
 /** [docs](https://nodejs.org/api/fs.html#fswritefilesyncfile-data-options) */
 @JsName("writeFileSync")
-internal external fun fs_writeFileSync(path: String, data: buffer_Buffer)
+internal external fun fs_writeFileSync(path: Path, data: buffer_Buffer)
 
 /** [docs](https://nodejs.org/api/fs.html#fswritefilesyncfile-data-options) */
 @JsName("writeFileSync")
-internal external fun fs_writeFileSync(path: String, data: ByteArray)
+internal external fun fs_writeFileSync(path: Path, data: ByteArray)
 
 /** [docs](https://nodejs.org/api/fs.html#fswritefilesyncfile-data-options) */
 @JsName("writeFileSync")
-internal external fun fs_writeFileSync(path: String, data: String)
+internal external fun fs_writeFileSync(path: Path, data: String)
 
 /** [docs](https://nodejs.org/api/fs.html#fslstatsyncpath-options) */
 @JsName("lstatSync")
-internal external fun fs_lstatSync(path: String): fs_Stats
+internal external fun fs_lstatSync(path: Path): fs_Stats
 
 /** [docs](https://nodejs.org/api/fs.html#fsstatsyncpath-options) */
 @JsName("statSync")
-internal external fun fs_statSync(path: String): fs_Stats
+internal external fun fs_statSync(path: Path): fs_Stats
 
 /** [docs](https://nodejs.org/api/fs.html#class-fsstats) */
 @JsName("Stats")

--- a/library/file/src/jsMain/kotlin/io/matthewnelson/kmp/file/internal/JsPath.kt
+++ b/library/file/src/jsMain/kotlin/io/matthewnelson/kmp/file/internal/JsPath.kt
@@ -25,12 +25,12 @@ internal external val path_sep: String
 
 /** [docs](https://nodejs.org/api/path.html#pathbasenamepath-suffix) **/
 @JsName("basename")
-internal external fun path_basename(path: String): String
+internal external fun path_basename(path: Path): String
 
 /** [docs](https://nodejs.org/api/path.html#pathdirnamepath) **/
 @JsName("dirname")
-internal external fun path_dirname(path: String): String
+internal external fun path_dirname(path: Path): String
 
 /** [docs](https://nodejs.org/api/path.html#pathisabsolutepath) **/
 @JsName("isAbsolute")
-internal external fun path_isAbsolute(path: String): Boolean
+internal external fun path_isAbsolute(path: Path): Boolean

--- a/library/file/src/jsMain/kotlin/io/matthewnelson/kmp/file/internal/JsPlatform.kt
+++ b/library/file/src/jsMain/kotlin/io/matthewnelson/kmp/file/internal/JsPlatform.kt
@@ -19,21 +19,19 @@ package io.matthewnelson.kmp.file.internal
 
 import io.matthewnelson.kmp.file.*
 
-internal actual val PlatformDirSeparator: Char by lazy {
-    try {
-        path_sep.first()
-    } catch (_: Throwable) {
-        '/'
-    }
+@Suppress("NOTHING_TO_INLINE", "FunctionName")
+internal actual inline fun PlatformDirSeparator(): Char = try {
+    path_sep.first()
+} catch (_: Throwable) {
+    '/'
 }
 
-internal actual val PlatformTempDirectory: File by lazy {
-    try {
-        os_tmpdir()
-    } catch (_: Throwable) {
-        "/tmp"
-    }.toFile()
-}
+@Suppress("NOTHING_TO_INLINE", "FunctionName")
+internal actual inline fun PlatformTempDirectory(): File = try {
+    os_tmpdir()
+} catch (_: Throwable) {
+    "/tmp"
+}.toFile()
 
 internal actual val IsWindows: Boolean by lazy {
     try {

--- a/library/file/src/jsMain/kotlin/io/matthewnelson/kmp/file/internal/JsPlatform.kt
+++ b/library/file/src/jsMain/kotlin/io/matthewnelson/kmp/file/internal/JsPlatform.kt
@@ -120,7 +120,7 @@ internal actual inline fun Path.isAbsolute(): Boolean {
 }
 
 // @Throws(IOException::class)
-internal actual fun fs_chmod(path: String, mode: String) {
+internal actual fun fs_chmod(path: Path, mode: String) {
     try {
         fs_chmodSync(path, mode)
     } catch (t: Throwable) {
@@ -129,7 +129,7 @@ internal actual fun fs_chmod(path: String, mode: String) {
 }
 
 // @Throws(IOException::class)
-internal actual fun fs_remove(path: String): Boolean {
+internal actual fun fs_remove(path: Path): Boolean {
     try {
         fs_unlinkSync(path)
         return true
@@ -154,7 +154,7 @@ internal actual fun fs_remove(path: String): Boolean {
     }
 }
 
-internal actual fun fs_mkdir(path: String): Boolean {
+internal actual fun fs_mkdir(path: Path): Boolean {
     return try {
         val options = js("{}")
         options["recursive"] = false
@@ -168,7 +168,7 @@ internal actual fun fs_mkdir(path: String): Boolean {
 }
 
 // @Throws(IOException::class)
-internal actual fun fs_realpath(path: String): String {
+internal actual fun fs_realpath(path: Path): Path {
     return try {
         fs_realpathSync(path)
     } catch (t: Throwable) {

--- a/library/file/src/jvmMain/kotlin/io/matthewnelson/kmp/file/internal/-JvmPlatform.kt
+++ b/library/file/src/jvmMain/kotlin/io/matthewnelson/kmp/file/internal/-JvmPlatform.kt
@@ -24,18 +24,14 @@ import kotlin.io.resolve as _resolve
 import kotlin.io.writeBytes as _writeBytes
 import kotlin.io.writeText as _writeText
 
-@JvmField
-@JvmSynthetic
-internal actual val PlatformDirSeparator: Char = File.separatorChar
+@Suppress("NOTHING_TO_INLINE", "FunctionName")
+internal actual inline fun PlatformDirSeparator(): Char = File.separatorChar
 
-@JvmField
-@JvmSynthetic
-internal actual val PlatformTempDirectory: File = System
+@Suppress("NOTHING_TO_INLINE", "FunctionName")
+internal actual inline fun PlatformTempDirectory(): File = System
     .getProperty("java.io.tmpdir")
     .toFile()
 
-@JvmField
-@JvmSynthetic
 internal actual val IsWindows: Boolean = System.getProperty("os.name")
     ?.ifBlank { null }
     ?.contains("windows", ignoreCase = true)

--- a/library/file/src/linuxMain/kotlin/io/matthewnelson/kmp/file/internal/LinuxFs.kt
+++ b/library/file/src/linuxMain/kotlin/io/matthewnelson/kmp/file/internal/LinuxFs.kt
@@ -26,14 +26,14 @@ import platform.posix.*
 @Suppress("NOTHING_TO_INLINE")
 @OptIn(ExperimentalForeignApi::class)
 internal actual inline fun fs_platform_chmod(
-    path: String,
+    path: Path,
     mode: UInt,
 ): Int = chmod(path, mode.convert()).convert()
 
 @Suppress("NOTHING_TO_INLINE")
 @OptIn(ExperimentalForeignApi::class)
 internal actual inline fun fs_platform_mkdir(
-    path: String,
+    path: Path,
     mode: UInt,
 ): Int = mkdir(path, mode.convert()).convert()
 

--- a/library/file/src/linuxMain/kotlin/io/matthewnelson/kmp/file/internal/LinuxPlatform.kt
+++ b/library/file/src/linuxMain/kotlin/io/matthewnelson/kmp/file/internal/LinuxPlatform.kt
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
+@file:Suppress("KotlinRedundantDiagnosticSuppress")
+
 package io.matthewnelson.kmp.file.internal
 
 import io.matthewnelson.kmp.file.File
@@ -22,7 +24,8 @@ import kotlinx.cinterop.toKString
 import platform.posix.getenv
 
 @OptIn(ExperimentalForeignApi::class)
-internal actual val PlatformTempDirectory: File by lazy {
+@Suppress("NOTHING_TO_INLINE", "FunctionName")
+internal actual inline fun PlatformTempDirectory(): File {
     val tmpdir = getenv("TMPDIR")
-    (tmpdir?.toKString() ?: "/tmp").toFile()
+    return (tmpdir?.toKString() ?: "/tmp").toFile()
 }

--- a/library/file/src/mingwMain/kotlin/io/matthewnelson/kmp/file/internal/MingwFs.kt
+++ b/library/file/src/mingwMain/kotlin/io/matthewnelson/kmp/file/internal/MingwFs.kt
@@ -39,11 +39,11 @@ import platform.posix.remove
 import platform.posix.rmdir
 
 @Throws(IOException::class)
-internal actual fun fs_chmod(path: String, mode: String) { /* no-op */ }
+internal actual fun fs_chmod(path: Path, mode: String) { /* no-op */ }
 
 @Throws(IOException::class)
 @OptIn(ExperimentalForeignApi::class)
-internal actual fun fs_remove(path: String): Boolean {
+internal actual fun fs_remove(path: Path): Boolean {
     if (remove(path) == 0) return true
 
     val err = errno
@@ -55,14 +55,12 @@ internal actual fun fs_remove(path: String): Boolean {
 }
 
 internal actual fun fs_platform_mkdir(
-    path: String,
+    path: Path,
 ): Int = mkdir(path)
 
 @Throws(IOException::class)
 @OptIn(ExperimentalForeignApi::class)
-internal actual fun fs_realpath(
-    path: String,
-): String {
+internal actual fun fs_realpath(path: Path): Path {
     val real = _fullpath(null, path, PATH_MAX.toULong())
         ?: throw errnoToIOException(errno)
 

--- a/library/file/src/mingwMain/kotlin/io/matthewnelson/kmp/file/internal/MingwPlatform.kt
+++ b/library/file/src/mingwMain/kotlin/io/matthewnelson/kmp/file/internal/MingwPlatform.kt
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
+@file:Suppress("KotlinRedundantDiagnosticSuppress")
+
 package io.matthewnelson.kmp.file.internal
 
 import io.matthewnelson.kmp.file.File
@@ -21,12 +23,14 @@ import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.toKString
 import platform.posix.getenv
 
-internal actual val PlatformDirSeparator: Char = '\\'
+@Suppress("NOTHING_TO_INLINE", "FunctionName")
+internal actual inline fun PlatformDirSeparator(): Char = '\\'
 
-@OptIn(ExperimentalForeignApi::class)
-internal actual val PlatformTempDirectory: File by lazy {
+@Suppress("NOTHING_TO_INLINE", "FunctionName")
+internal actual inline fun PlatformTempDirectory(): File {
     // Windows' built-in APIs check the TEMP, TMP, and USERPROFILE environment variables in order.
     // https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-gettemppatha?redirectedfrom=MSDN
+    @OptIn(ExperimentalForeignApi::class)
     val temp = getenv("TEMP")
         ?.toKString()
         ?: getenv("TMP")
@@ -35,7 +39,7 @@ internal actual val PlatformTempDirectory: File by lazy {
             ?.toKString()
         ?: "\\Windows\\TEMP"
 
-    temp.toFile()
+    return temp.toFile()
 }
 
 internal actual val IsWindows: Boolean = true

--- a/library/file/src/nativeMain/kotlin/io/matthewnelson/kmp/file/internal/NativeFs.kt
+++ b/library/file/src/nativeMain/kotlin/io/matthewnelson/kmp/file/internal/NativeFs.kt
@@ -25,7 +25,7 @@ import platform.posix.FILE
 import platform.posix.access
 import platform.posix.errno
 
-internal actual fun fs_exists(path: String): Boolean {
+internal actual fun fs_exists(path: Path): Boolean {
     val result = access(path, 0)
     return if (result != 0 && errno == ENOENT) {
         false
@@ -34,11 +34,11 @@ internal actual fun fs_exists(path: String): Boolean {
     }
 }
 
-internal actual fun fs_mkdir(path: String): Boolean {
+internal actual fun fs_mkdir(path: Path): Boolean {
     return fs_platform_mkdir(path) == 0
 }
 
-internal expect fun fs_platform_mkdir(path: String): Int
+internal expect fun fs_platform_mkdir(path: Path): Int
 
 @ExperimentalForeignApi
 @Suppress("NOTHING_TO_INLINE")

--- a/library/file/src/nonJvmMain/kotlin/io/matthewnelson/kmp/file/internal/-NonJvmPlatform.kt
+++ b/library/file/src/nonJvmMain/kotlin/io/matthewnelson/kmp/file/internal/-NonJvmPlatform.kt
@@ -27,8 +27,8 @@ internal actual inline fun File.platformResolve(relative: File): File = when {
     // rooted it will be returned instead of concatenating
     // it with the parent path. isAbsolute would return false
     // if the path on windows was relative, like `\Windows`.
-    relative.path.startsWith(PlatformDirSeparator) -> relative
+    relative.path.startsWith(SysDirSep) -> relative
     relative.isAbsolute() -> relative
-    path.endsWith(PlatformDirSeparator) -> File(path + relative.path)
-    else -> File(path + PlatformDirSeparator + relative.path)
+    path.endsWith(SysDirSep) -> File(path + relative.path)
+    else -> File(path + SysDirSep + relative.path)
 }

--- a/library/file/src/nonJvmMain/kotlin/io/matthewnelson/kmp/file/internal/NonJvmFs.kt
+++ b/library/file/src/nonJvmMain/kotlin/io/matthewnelson/kmp/file/internal/NonJvmFs.kt
@@ -20,7 +20,7 @@ package io.matthewnelson.kmp.file.internal
 import io.matthewnelson.kmp.file.IOException
 
 @Throws(IOException::class)
-internal fun fs_canonicalize(path: String): String {
+internal fun fs_canonicalize(path: Path): Path {
     if (path.isEmpty()) return fs_realpath(".")
 
     val resolved = path.absolute().normalize()
@@ -37,13 +37,13 @@ internal fun fs_canonicalize(path: String): String {
 }
 
 @Throws(IOException::class)
-internal expect fun fs_chmod(path: String, mode: String)
+internal expect fun fs_chmod(path: Path, mode: String)
 
-internal expect fun fs_exists(path: String): Boolean
+internal expect fun fs_exists(path: Path): Boolean
 
-internal expect fun fs_mkdir(path: String): Boolean
+internal expect fun fs_mkdir(path: Path): Boolean
 
-internal fun fs_mkdirs(path: String): Boolean {
+internal fun fs_mkdirs(path: Path): Boolean {
     if (fs_mkdir(path)) return true
 
     val dirsToMake = try {
@@ -70,7 +70,7 @@ internal fun fs_mkdirs(path: String): Boolean {
 }
 
 @Throws(IOException::class)
-internal expect fun fs_remove(path: String): Boolean
+internal expect fun fs_remove(path: Path): Boolean
 
 @Throws(IOException::class)
-internal expect fun fs_realpath(path: String): String
+internal expect fun fs_realpath(path: Path): Path

--- a/library/file/src/unixMain/kotlin/io/matthewnelson/kmp/file/internal/UnixFs.kt
+++ b/library/file/src/unixMain/kotlin/io/matthewnelson/kmp/file/internal/UnixFs.kt
@@ -25,7 +25,7 @@ import platform.posix.*
 
 @Throws(IOException::class)
 @OptIn(ExperimentalForeignApi::class)
-internal actual fun fs_chmod(path: String, mode: String) {
+internal actual fun fs_chmod(path: Path, mode: String) {
     val modeT = try {
         Mode(value = mode).toModeT()
     } catch (e: IllegalArgumentException) {
@@ -40,7 +40,7 @@ internal actual fun fs_chmod(path: String, mode: String) {
 
 @Throws(IOException::class)
 @OptIn(ExperimentalForeignApi::class)
-internal actual fun fs_remove(path: String): Boolean {
+internal actual fun fs_remove(path: Path): Boolean {
     val result = remove(path)
     if (result != 0) {
         if (errno == ENOENT) return false
@@ -51,7 +51,7 @@ internal actual fun fs_remove(path: String): Boolean {
 
 @Throws(IOException::class)
 @OptIn(ExperimentalForeignApi::class)
-internal actual fun fs_realpath(path: String): String {
+internal actual fun fs_realpath(path: Path): Path {
     val real = realpath(path, null)
         ?: throw errnoToIOException(errno)
 
@@ -63,18 +63,18 @@ internal actual fun fs_realpath(path: String): String {
 }
 
 internal actual fun fs_platform_mkdir(
-    path: String,
+    path: Path,
 ): Int = fs_platform_mkdir(path, Mode("775").toModeT())
 
 @Suppress("NOTHING_TO_INLINE")
 internal expect inline fun fs_platform_chmod(
-    path: String,
+    path: Path,
     mode: UInt,
 ): Int
 
 @Suppress("NOTHING_TO_INLINE")
 internal expect inline fun fs_platform_mkdir(
-    path: String,
+    path: Path,
     mode: UInt,
 ): Int
 

--- a/library/file/src/unixMain/kotlin/io/matthewnelson/kmp/file/internal/UnixPlatform.kt
+++ b/library/file/src/unixMain/kotlin/io/matthewnelson/kmp/file/internal/UnixPlatform.kt
@@ -13,8 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
+@file:Suppress("KotlinRedundantDiagnosticSuppress")
+
 package io.matthewnelson.kmp.file.internal
 
-internal actual val PlatformDirSeparator: Char = '/'
+@Suppress("NOTHING_TO_INLINE", "FunctionName")
+internal actual inline fun PlatformDirSeparator(): Char = '/'
 
 internal actual val IsWindows: Boolean = false


### PR DESCRIPTION
Modifies the platform specific calls that back `SysDirSep` and `SysTempDir` so that they are inline functions (and only invoked once, from their respective public values.

Cleans up some code.