### PR TITLE
Refactor `Node.js` `Buffer` wrapper

### DIFF
--- a/library/file/src/jsMain/kotlin/io/matthewnelson/kmp/file/FileJs.kt
+++ b/library/file/src/jsMain/kotlin/io/matthewnelson/kmp/file/FileJs.kt
@@ -16,7 +16,6 @@
 package io.matthewnelson.kmp.file
 
 import io.matthewnelson.kmp.file.internal.*
-import io.matthewnelson.kmp.file.internal.errorCode
 
 // @Throws(IOException::class)
 public fun File.lstat(): Stats = try {
@@ -48,10 +47,16 @@ public fun File.write(data: Buffer) {
     }
 }
 
+public val Throwable.errorCodeOrNull: String? get() = try {
+    asDynamic().code as String
+} catch (_: Throwable) {
+    null
+}
+
 public fun Throwable.toIOException(): IOException {
     if (this is IOException) return this
 
-    return when (errorCode) {
+    return when (errorCodeOrNull) {
         "ENOENT" -> FileNotFoundException(message)
         else -> IOException(this)
     }

--- a/library/file/src/jsMain/kotlin/io/matthewnelson/kmp/file/Wrappers.kt
+++ b/library/file/src/jsMain/kotlin/io/matthewnelson/kmp/file/Wrappers.kt
@@ -15,9 +15,11 @@
  **/
 package io.matthewnelson.kmp.file
 
+import io.matthewnelson.kmp.file.internal.*
 import io.matthewnelson.kmp.file.internal.buffer_Buffer
 import io.matthewnelson.kmp.file.internal.errorCode
 import io.matthewnelson.kmp.file.internal.fs_Stats
+import io.matthewnelson.kmp.file.internal.toNotLong
 
 /**
  * If printing to console, use [unwrap] beforehand, otherwise
@@ -28,16 +30,14 @@ import io.matthewnelson.kmp.file.internal.fs_Stats
  *     println(buffer.unwrap())
  *
  * */
-public value class Buffer internal constructor(
-    internal val value: buffer_Buffer
-) {
+public value class Buffer internal constructor(internal val value: buffer_Buffer) {
 
-    public val length: Long get() = value.length.toLong()
+    public val length: Number get() = value.length
     public fun fill() { value.fill() }
 
     // @Throws(IndexOutOfBoundsException::class, IllegalArgumentException::class)
     public fun readInt8(index: Number): Byte = try {
-        value.readInt8(index) as Byte
+        value.readInt8(index.toNotLong()) as Byte
     } catch (t: Throwable) {
         throw when (t.errorCode) {
             "ERR_OUT_OF_RANGE" -> IndexOutOfBoundsException(t.message)
@@ -48,7 +48,7 @@ public value class Buffer internal constructor(
     public fun toUtf8(
         start: Number = 0,
         end: Number = this.length,
-    ): String = value.toString("utf8", start, end)
+    ): String = value.toString("utf8", start.toNotLong(), end.toNotLong())
 
     public fun unwrap(): dynamic = value.asDynamic()
 
@@ -56,20 +56,25 @@ public value class Buffer internal constructor(
 
     public companion object {
 
+        public val MAX_LENGTH: Number get() = kMaxLength
+
+        // @Throws(IllegalArgumentException::class)
+        public fun alloc(size: Number): Buffer = try {
+            Buffer(buffer_Buffer.alloc(size.toNotLong()))
+        } catch (t: Throwable) {
+            throw IllegalArgumentException(t)
+        }
+
         // @Throws(IllegalArgumentException::class)
         public fun wrap(buffer: dynamic): Buffer {
-            if (!buffer_Buffer.isBuffer(buffer)) {
-                throw IllegalArgumentException("Not a buffer")
-            }
-
+            require(buffer_Buffer.isBuffer(buffer)) { "Object is not a buffer" }
             return Buffer(buffer.unsafeCast<buffer_Buffer>())
         }
     }
 }
 
-public value class Stats internal constructor(
-    private val value: fs_Stats
-) {
+public value class Stats internal constructor(private val value: fs_Stats) {
+
     public val mode: Int get() = value.mode as Int
     public val isFile: Boolean get() = value.isFile()
     public val isDirectory: Boolean get() = value.isDirectory()

--- a/library/file/src/jsMain/kotlin/io/matthewnelson/kmp/file/Wrappers.kt
+++ b/library/file/src/jsMain/kotlin/io/matthewnelson/kmp/file/Wrappers.kt
@@ -17,7 +17,6 @@ package io.matthewnelson.kmp.file
 
 import io.matthewnelson.kmp.file.internal.*
 import io.matthewnelson.kmp.file.internal.buffer_Buffer
-import io.matthewnelson.kmp.file.internal.errorCode
 import io.matthewnelson.kmp.file.internal.fs_Stats
 import io.matthewnelson.kmp.file.internal.toNotLong
 
@@ -39,7 +38,7 @@ public value class Buffer internal constructor(internal val value: buffer_Buffer
     public fun readInt8(index: Number): Byte = try {
         value.readInt8(index.toNotLong()) as Byte
     } catch (t: Throwable) {
-        throw when (t.errorCode) {
+        throw when (t.errorCodeOrNull) {
             "ERR_OUT_OF_RANGE" -> IndexOutOfBoundsException(t.message)
             else -> IllegalArgumentException(t)
         }

--- a/library/file/src/jsMain/kotlin/io/matthewnelson/kmp/file/internal/JsBuffer.kt
+++ b/library/file/src/jsMain/kotlin/io/matthewnelson/kmp/file/internal/JsBuffer.kt
@@ -19,15 +19,22 @@
 
 package io.matthewnelson.kmp.file.internal
 
+/** [docs](https://nodejs.org/api/buffer.html#bufferconstantsmax_length) */
+internal external val kMaxLength: Number
+
 /** [docs](https://nodejs.org/api/buffer.html#class-buffer) */
 @JsName("Buffer")
 internal external class buffer_Buffer {
+
     internal val length: Number
+
     internal fun fill()
     internal fun readInt8(offset: Number): Number
     internal fun toString(encoding: String, start: Number, end: Number): String
 
     internal companion object {
+
+        internal fun alloc(size: Number): buffer_Buffer
         internal fun isBuffer(obj: dynamic): Boolean
     }
 }

--- a/library/file/src/jsMain/kotlin/io/matthewnelson/kmp/file/internal/JsPlatform.kt
+++ b/library/file/src/jsMain/kotlin/io/matthewnelson/kmp/file/internal/JsPlatform.kt
@@ -135,7 +135,7 @@ internal actual fun fs_remove(path: Path): Boolean {
         fs_unlinkSync(path)
         return true
     } catch (t: Throwable) {
-        if (t.errorCode == "ENOENT") return false
+        if (t.errorCodeOrNull == "ENOENT") return false
     }
 
     val options = js("{}")
@@ -187,11 +187,4 @@ internal inline fun Number.toNotLong(): Number {
     } else {
         toDouble()
     }
-}
-
-@Suppress("NOTHING_TO_INLINE", "REDUNDANT_NULLABLE")
-internal inline val Throwable.errorCode: String? get() = try {
-    asDynamic().code as String
-} catch (_: Throwable) {
-    null
 }

--- a/library/file/src/jsTest/kotlin/io/matthewnelson/kmp/file/WrapperUnitTest.kt
+++ b/library/file/src/jsTest/kotlin/io/matthewnelson/kmp/file/WrapperUnitTest.kt
@@ -15,6 +15,7 @@
  **/
 package io.matthewnelson.kmp.file
 
+import io.matthewnelson.kmp.file.internal.toNotLong
 import kotlin.test.*
 
 class WrapperUnitTest {
@@ -47,5 +48,22 @@ class WrapperUnitTest {
         val buf = js("Buffer").alloc(0)
         val string = Buffer.wrap(buf).toUtf8()
         assertTrue(string.isEmpty())
+    }
+
+    @Test
+    fun givenBufferAlloc_whenExceedsIntMax_thenConvertsToDoubleUnderTheHood() {
+        val long = Int.MAX_VALUE.toLong()
+        val number = (long + 1000).toNotLong()
+        assertIs<Double>(number)
+
+        // Should be fine b/c I do not think Kotlin supports 32-bit
+        // arch, so max value will always be 9007199254740991
+        Buffer.alloc(number)
+    }
+
+    @Test
+    fun givenBuffer_whenMAXLENGTH_thenIsDefined() {
+        // would throw exception if undefined
+        Buffer.MAX_LENGTH.toLong()
     }
 }


### PR DESCRIPTION
Closes #66 

Does a few minor things here
1) Adds `Buffer.alloc` static function
2) Adds `Buffer.MAX_LENGTH` variable
3) `Buffer.length` no returns `Number` instead of `Long`
4) `Throwable.errorCodeOrNull` is now public