### PR TITLE
Fix potential multi-slash result for non-jvm `File.absolutePath`

### DIFF
--- a/library/file/src/nonJvmMain/kotlin/io/matthewnelson/kmp/file/File.kt
+++ b/library/file/src/nonJvmMain/kotlin/io/matthewnelson/kmp/file/File.kt
@@ -86,7 +86,7 @@ public actual class File: Comparable<File> {
 
     // use .absolutePath
     @PublishedApi
-    internal actual fun getAbsolutePath(): String = realPath.absolute()
+    internal actual fun getAbsolutePath(): String = realPath.absolute().resolveSlashes()
     // use .absoluteFile
     @PublishedApi
     internal actual fun getAbsoluteFile(): File {

--- a/test-android/src/androidInstrumentedTest/kotlin/io/matthewnelson/kmp/file/test/android/AndroidNativeExecutableAndroidTest.kt
+++ b/test-android/src/androidInstrumentedTest/kotlin/io/matthewnelson/kmp/file/test/android/AndroidNativeExecutableAndroidTest.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2024 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.matthewnelson.kmp.file.test.android
+
+import android.app.Application
+import android.os.Build
+import androidx.test.core.app.ApplicationProvider
+import io.matthewnelson.kmp.file.FileNotFoundException
+import io.matthewnelson.kmp.file.SysTempDir
+import io.matthewnelson.kmp.file.toFile
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.minutes
+
+class AndroidNativeExecutableAndroidTest {
+
+    private val ctx = ApplicationProvider.getApplicationContext<Application>()
+    private val nativeLibDir = ctx.applicationInfo.nativeLibraryDir.toFile()
+
+    @Test
+    fun givenAndroidNative_whenExecuteTestBinary_thenIsSuccessful() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            println("Skipping...")
+            return
+        }
+
+        val executable = findLibTestExec()
+
+        var p: Process? = null
+        try {
+            p = ProcessBuilder(listOf(executable.path)).apply {
+                redirectErrorStream(true)
+                val env = environment()
+                env["kmp.file.test.EXPECTED_TEMP_PATH"] = SysTempDir.path
+                env["kmp.file.test.EXPECTED_ABSOLUTE_PATH_EMPTY"] = "".toFile().absolutePath
+                env["kmp.file.test.EXPECTED_ABSOLUTE_PATH_DOT"] = ".".toFile().absolutePath
+                env["kmp.file.test.EXPECTED_CANONICAL_PATH_EMPTY"] = "".toFile().canonicalPath
+                env["kmp.file.test.EXPECTED_CANONICAL_PATH_DOT"] = ".".toFile().canonicalPath
+            }.start()
+
+            p.outputStream.close()
+
+            var isComplete = false
+            Thread {
+                try {
+                    p.inputStream.use { s ->
+                        val buf = ByteArray(DEFAULT_BUFFER_SIZE * 2)
+                        while (true) {
+                            val read = s.read(buf)
+                            if (read == -1) break
+                            System.out.write(buf, 0, read)
+                        }
+                    }
+                } finally {
+                    isComplete = true
+                }
+            }.apply {
+                isDaemon = true
+                priority = Thread.MAX_PRIORITY
+            }.start()
+
+            var timeout = 1.minutes
+            while (true) {
+                if (isComplete) break
+                if (timeout <= Duration.ZERO) break
+
+                Thread.sleep(100)
+                timeout -= 100.milliseconds
+            }
+        } finally {
+            p?.destroy()
+        }
+
+        assertNotNull(p)
+
+        var exit: Int? = null
+        while (exit == null) {
+            try {
+                exit = p.exitValue()
+            } catch (_: IllegalThreadStateException) {
+                Thread.sleep(50)
+            }
+        }
+
+        assertEquals(0, exit)
+    }
+
+    private fun findLibTestExec(): File {
+        nativeLibDir.walkTopDown().iterator().forEach { file ->
+            if (!file.isFile) return@forEach
+            if (file.name != "libTestExec.so") return@forEach
+            if (!file.canExecute()) return@forEach
+            return file
+        }
+
+        throw FileNotFoundException("libTestExec.so was not found...")
+    }
+}

--- a/test-android/src/androidInstrumentedTest/kotlin/io/matthewnelson/kmp/file/test/android/SysTempDirAndroidTest.kt
+++ b/test-android/src/androidInstrumentedTest/kotlin/io/matthewnelson/kmp/file/test/android/SysTempDirAndroidTest.kt
@@ -54,6 +54,10 @@ class SysTempDirAndroidTest {
                 redirectErrorStream(true)
                 val env = environment()
                 env["kmp.file.test.EXPECTED_TEMP_PATH"] = SysTempDir.path
+                env["kmp.file.test.EXPECTED_ABSOLUTE_PATH_EMPTY"] = "".toFile().absolutePath
+                env["kmp.file.test.EXPECTED_ABSOLUTE_PATH_DOT"] = ".".toFile().absolutePath
+                env["kmp.file.test.EXPECTED_CANONICAL_PATH_EMPTY"] = "".toFile().canonicalPath
+                env["kmp.file.test.EXPECTED_CANONICAL_PATH_DOT"] = ".".toFile().canonicalPath
             }.start()
 
             p.outputStream.close()

--- a/test-android/src/androidInstrumentedTest/kotlin/io/matthewnelson/kmp/file/test/android/SysTempDirAndroidTest.kt
+++ b/test-android/src/androidInstrumentedTest/kotlin/io/matthewnelson/kmp/file/test/android/SysTempDirAndroidTest.kt
@@ -16,105 +16,17 @@
 package io.matthewnelson.kmp.file.test.android
 
 import android.app.Application
-import android.os.Build
 import androidx.test.core.app.ApplicationProvider
-import io.matthewnelson.kmp.file.FileNotFoundException
 import io.matthewnelson.kmp.file.SysTempDir
-import io.matthewnelson.kmp.file.toFile
-import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.time.Duration
-import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.minutes
 
 class SysTempDirAndroidTest {
 
     private val ctx = ApplicationProvider.getApplicationContext<Application>()
-    private val nativeLibDir = ctx.applicationInfo.nativeLibraryDir.toFile()
 
     @Test
     fun givenAndroidRuntime_whenSysTempDir_thenIsSameAsCacheDir() {
         assertEquals(ctx.cacheDir, SysTempDir)
-    }
-
-    @Test
-    fun givenAndroidNative_whenExecuteTestBinary_thenIsSuccessful() {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-            println("Skipping...")
-            return
-        }
-
-        val executable = findLibTestExec()
-
-        var p: Process? = null
-        try {
-            p = ProcessBuilder(listOf(executable.path)).apply {
-                redirectErrorStream(true)
-                val env = environment()
-                env["kmp.file.test.EXPECTED_TEMP_PATH"] = SysTempDir.path
-                env["kmp.file.test.EXPECTED_ABSOLUTE_PATH_EMPTY"] = "".toFile().absolutePath
-                env["kmp.file.test.EXPECTED_ABSOLUTE_PATH_DOT"] = ".".toFile().absolutePath
-                env["kmp.file.test.EXPECTED_CANONICAL_PATH_EMPTY"] = "".toFile().canonicalPath
-                env["kmp.file.test.EXPECTED_CANONICAL_PATH_DOT"] = ".".toFile().canonicalPath
-            }.start()
-
-            p.outputStream.close()
-
-            var isComplete = false
-            Thread {
-                try {
-                    p.inputStream.use { s ->
-                        val buf = ByteArray(DEFAULT_BUFFER_SIZE * 2)
-                        while (true) {
-                            val read = s.read(buf)
-                            if (read == -1) break
-                            System.out.write(buf, 0, read)
-                        }
-                    }
-                } finally {
-                    isComplete = true
-                }
-            }.apply {
-                isDaemon = true
-                priority = Thread.MAX_PRIORITY
-            }.start()
-
-            var timeout = 1.minutes
-            while (true) {
-                if (isComplete) break
-                if (timeout <= Duration.ZERO) break
-
-                Thread.sleep(100)
-                timeout -= 100.milliseconds
-            }
-        } finally {
-            p?.destroy()
-        }
-
-        assertNotNull(p)
-
-        var exit: Int? = null
-        while (exit == null) {
-            try {
-                exit = p.exitValue()
-            } catch (_: IllegalThreadStateException) {
-                Thread.sleep(50)
-            }
-        }
-
-        assertEquals(0, exit)
-    }
-
-    private fun findLibTestExec(): File {
-        nativeLibDir.walkTopDown().iterator().forEach { file ->
-            if (!file.isFile) return@forEach
-            if (file.name != "libTestExec.so") return@forEach
-            if (!file.canExecute()) return@forEach
-            return file
-        }
-
-        throw FileNotFoundException("libTestExec.so was not found...")
     }
 }

--- a/test-android/src/androidNativeTest/kotlin/io/matthewnelson/kmp/file/test/android/AndroidNativeTest.kt
+++ b/test-android/src/androidNativeTest/kotlin/io/matthewnelson/kmp/file/test/android/AndroidNativeTest.kt
@@ -51,7 +51,29 @@ class AndroidNativeTest {
         }
     }
 
+    @Test
+    fun givenEmptyFilePath_whenAbsolutePath_thenMatchesExpected() {
+        assertEquals(requireEnv("kmp.file.test.EXPECTED_ABSOLUTE_PATH_EMPTY"), "".toFile().absolutePath)
+    }
+
+    @Test
+    fun givenDotFilePath_whenAbsolutePath_thenMatchesExpected() {
+        assertEquals(requireEnv("kmp.file.test.EXPECTED_ABSOLUTE_PATH_DOT"), ".".toFile().absolutePath)
+    }
+
+
+    @Test
+    fun givenEmptyFilePath_whenCanonicalPath_thenMatchesExpected() {
+        assertEquals(requireEnv("kmp.file.test.EXPECTED_CANONICAL_PATH_EMPTY"), "".toFile().canonicalPath())
+    }
+
+    @Test
+    fun givenDotFilePath_whenCanonicalPath_thenMatchesExpected() {
+        assertEquals(requireEnv("kmp.file.test.EXPECTED_CANONICAL_PATH_DOT"), ".".toFile().canonicalPath())
+    }
+
     private fun requireEnv(key: String): String = getenv(key)
         ?.toKString()
+        ?.ifBlank { null }
         ?: throw IllegalStateException("Environment variable does not exist for key[$key]")
 }


### PR DESCRIPTION
Closes #87 