### PR TITLE
Remove `System.property` check `java.runtime.name` and only utilize reflection when procuring android `SDK_INT`

### DIFF
--- a/library/file/src/jvmMain/kotlin/io/matthewnelson/kmp/file/ANDROID.kt
+++ b/library/file/src/jvmMain/kotlin/io/matthewnelson/kmp/file/ANDROID.kt
@@ -20,17 +20,14 @@ public object ANDROID {
     /**
      * Reflection based retrieval of android.os.Build.VERSION.SDK_INT
      *
-     * Will be null if not android runtime (i.e. not an emulator or device)
+     * Will be either:
+     *  - `null`: NOT Android Runtime (i.e. not an emulator or device)
+     *  - 1 or greater: Android Runtime
      * */
     @JvmField
     public val SDK_INT: Int? = run {
-        val isAndroidRuntime = System.getProperty("java.runtime.name")
-            ?.contains("android", ignoreCase = true) == true
-
-        if (!isAndroidRuntime) return@run null
-
-        try {
-            val clazz = Class.forName("android.os.Build\$VERSION")
+        val sdk = try {
+            val clazz: Class<*>? = Class.forName("android.os.Build\$VERSION")
 
             try {
                 clazz?.getField("SDK_INT")?.getInt(null)
@@ -39,6 +36,11 @@ public object ANDROID {
             }
         } catch (_: Throwable) {
             null
-        }
+        } ?: return@run null
+
+        // Will be 0 for Android Unit tests
+        if (sdk <= 0) return@run null
+
+        sdk
     }
 }

--- a/library/file/src/jvmTest/kotlin/io/matthewnelson/kmp/file/AndroidSdkIntJvmUnitTest.kt
+++ b/library/file/src/jvmTest/kotlin/io/matthewnelson/kmp/file/AndroidSdkIntJvmUnitTest.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025 Matthew Nelson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package io.matthewnelson.kmp.file
+
+import kotlin.test.Test
+import kotlin.test.assertNull
+
+class AndroidSdkIntJvmUnitTest {
+
+    @Test
+    fun givenJava_whenSdkInt_thenIsNull() {
+        assertNull(ANDROID.SDK_INT)
+    }
+}


### PR DESCRIPTION
System property can be manipulated, so a more stable approach is to always check via reflection, then if greater than 0, use it.