### PR TITLE
Throw `IllegalArgumentException` instead of `IOException` when `File.chmod` mode string is not valid

### DIFF
--- a/library/file/src/jsTest/kotlin/io/matthewnelson/kmp/file/ChmodJsUnitTest.kt
+++ b/library/file/src/jsTest/kotlin/io/matthewnelson/kmp/file/ChmodJsUnitTest.kt
@@ -15,4 +15,5 @@
  **/
 package io.matthewnelson.kmp.file
 
+@Suppress("UNUSED")
 class ChmodJsUnitTest: ChmodBaseTest()

--- a/library/file/src/nativeMain/kotlin/io/matthewnelson/kmp/file/internal/NativeFs.kt
+++ b/library/file/src/nativeMain/kotlin/io/matthewnelson/kmp/file/internal/NativeFs.kt
@@ -21,7 +21,6 @@ import io.matthewnelson.kmp.file.File
 import io.matthewnelson.kmp.file.IOException
 import io.matthewnelson.kmp.file.OpenExcl
 import io.matthewnelson.kmp.file.errnoToIOException
-import io.matthewnelson.kmp.file.wrapIOException
 import kotlinx.cinterop.ByteVar
 import kotlinx.cinterop.CPointer
 import kotlinx.cinterop.ExperimentalForeignApi
@@ -31,17 +30,11 @@ import platform.posix.FILE
 import platform.posix.access
 import platform.posix.errno
 
-@Throws(IOException::class)
 @OptIn(ExperimentalForeignApi::class)
+@Throws(IllegalArgumentException::class, IOException::class)
 internal actual fun fs_chmod(path: Path, mode: String) {
-    val modeT = try {
-        ModeT.get(mode)
-    } catch (e: IllegalArgumentException) {
-        throw e.wrapIOException()
-    }
-
-    val result = fs_platform_chmod(path, modeT)
-    if (result != 0) {
+    val modeT = ModeT.get(mode)
+    if (fs_platform_chmod(path, modeT) != 0) {
         throw errnoToIOException(errno)
     }
 }

--- a/library/file/src/nonJvmMain/kotlin/io/matthewnelson/kmp/file/File.kt
+++ b/library/file/src/nonJvmMain/kotlin/io/matthewnelson/kmp/file/File.kt
@@ -45,8 +45,9 @@ public actual class File: Comparable<File> {
      * @param [mode] The permissions to set. Must be 3 digits, each
      *   being between `0` and `7` (inclusive).
      *
-     * @throws [IOException] if [mode] is inappropriate
-     * @throws [FileNotFoundException] if the file does not exist
+     * @throws [IllegalArgumentException] if [mode] is inappropriate.
+     * @throws [FileNotFoundException] if the file does not exist.
+     * @throws [IOException] if there was a failure to apply desired permissions.
      * */
     @Throws(IOException::class)
     public fun chmod(mode: String) { fs_chmod(realPath, mode) }

--- a/library/file/src/nonJvmMain/kotlin/io/matthewnelson/kmp/file/internal/NonJvmFs.kt
+++ b/library/file/src/nonJvmMain/kotlin/io/matthewnelson/kmp/file/internal/NonJvmFs.kt
@@ -36,7 +36,7 @@ internal fun fs_canonicalize(path: Path): Path {
     return resolved.replaceFirst(existingPath, fs_realpath(existingPath))
 }
 
-@Throws(IOException::class)
+@Throws(IllegalArgumentException::class, IOException::class)
 internal expect fun fs_chmod(path: Path, mode: String)
 
 internal expect fun fs_exists(path: Path): Boolean

--- a/library/file/src/nonJvmTest/kotlin/io/matthewnelson/kmp/file/ChmodBaseTest.kt
+++ b/library/file/src/nonJvmTest/kotlin/io/matthewnelson/kmp/file/ChmodBaseTest.kt
@@ -23,7 +23,7 @@ import kotlin.test.fail
 abstract class ChmodBaseTest {
 
     @Test
-    fun givenFile_whenIllegalMode_thenThrowsIOException() {
+    fun givenFile_whenIllegalMode_thenThrowsIllegalArgumentException() {
         if (IsWindows) return
 
         val tmp = randomTemp()
@@ -39,7 +39,7 @@ abstract class ChmodBaseTest {
                 try {
                     tmp.chmod(mode)
                     fail(message = mode)
-                } catch (_: IOException) {
+                } catch (_: IllegalArgumentException) {
                     // pass
                 }
             }


### PR DESCRIPTION
Closes #100 