### PR TITLE
Only println on error

### DIFF
--- a/library/file/src/jvmMain/kotlin/io/matthewnelson/kmp/file/internal/fs/-FsJvmAndroid.kt
+++ b/library/file/src/jvmMain/kotlin/io/matthewnelson/kmp/file/internal/fs/-FsJvmAndroid.kt
@@ -345,9 +345,9 @@ internal class FsJvmAndroid private constructor(
             file.delete()
         } catch (_: Throwable) {}
 
-        if (result != null) {
+        if (result == null) {
             try {
-                println("KMP-FILE: O_CLOEXEC for API[${ANDROID.SDK_INT}] found to be $result")
+                System.err.println("KMP-FILE: Failed to determine O_CLOEXEC value for API[${ANDROID.SDK_INT}]")
             } catch (_: Throwable) {}
         }
 

--- a/library/file/src/jvmMain/kotlin/io/matthewnelson/kmp/file/internal/fs/-FsJvmAndroid.kt
+++ b/library/file/src/jvmMain/kotlin/io/matthewnelson/kmp/file/internal/fs/-FsJvmAndroid.kt
@@ -306,7 +306,7 @@ internal class FsJvmAndroid private constructor(
     // even though it is present in NDK for API 21+.
     //
     // This is a one time check for API 26 and below to verify supplemental value
-    // of 524288 by opening a temporary file with it and then verifying via fcntl
+    // of 0x80000 by opening a temporary file with it and then verifying via fcntl
     // that it has the FD_CLOEXEC flag.
     //
     // If it does not, or a failure to open the descriptor occurs, then null is
@@ -316,7 +316,7 @@ internal class FsJvmAndroid private constructor(
         if (const.O_CLOEXEC != null) return@lazy const.O_CLOEXEC
         if (os.fcntlVoid == null) return@lazy null
 
-        val O_CLOEXEC = 524288
+        val O_CLOEXEC = 0x80000 // 524288
         val m = MODE_MASK.convert(Mode.DEFAULT_FILE)
         val f = const.O_WRONLY or const.O_TRUNC or O_CLOEXEC or const.O_CREAT or const.O_EXCL
         val file = SysTempDir.resolve(UUID.randomUUID().toString())


### PR DESCRIPTION
#126 added a `println` statement for API 26 and below that fires when successfully verifying supplemental `O_CLOEXEC` value. This changes it to instead print to stderr only in the event of a failure.