### PR TITLE
Use `777` & `666` for default dir/file permissions, instead of `775`/`664`

### DIFF
--- a/library/file/src/commonMain/kotlin/io/matthewnelson/kmp/file/KmpFile.kt
+++ b/library/file/src/commonMain/kotlin/io/matthewnelson/kmp/file/KmpFile.kt
@@ -272,7 +272,7 @@ public fun File.resolve(relative: String): File {
  * e.g.
  *
  *     // The default POSIX file permissions for a new file
- *     myFile.chmod2("664")
+ *     myFile.chmod2("666")
  *
  * **POSIX permissions:**
  * - 7: READ | WRITE | EXECUTE
@@ -360,7 +360,7 @@ public fun File.exists2(): Boolean {
  *
  * @param [mode] The permissions to set for the newly created directory.
  *   Must be 3 digits, each being between `0` and `7` (inclusive). If
- *   `null`, default directory permissions `775` will be used.
+ *   `null`, default directory permissions `777` will be used.
  * @param [mustCreate] If `false`, failure to create the directory
  *   due to it already existing on the filesystem will return safely,
  *   instead of throwing [FileAlreadyExistsException]. If `true`, then
@@ -395,7 +395,7 @@ public fun File.mkdir2(mode: String?, mustCreate: Boolean = false): File {
  * @param [mode] The permissions to set for the newly created directory
  *   and any necessary, but nonexistent parent directories that were
  *   created. Must be 3 digits, each being between `0` and `7` (inclusive).
- *   If `null`, default directory permissions `775` will be used.
+ *   If `null`, default directory permissions `777` will be used.
  * @param [mustCreate] If `false`, failure to create the directory
  *   due to it already existing on the filesystem will return safely,
  *   instead of throwing [FileAlreadyExistsException]. If `true`, then

--- a/library/file/src/commonMain/kotlin/io/matthewnelson/kmp/file/OpenExcl.kt
+++ b/library/file/src/commonMain/kotlin/io/matthewnelson/kmp/file/OpenExcl.kt
@@ -51,14 +51,14 @@ public sealed class OpenExcl private constructor(internal val _mode: Mode) {
         public companion object {
 
             /**
-             * The default [MaybeCreate] value with permissions `664`.
+             * The default [MaybeCreate] value with permissions `666`.
              * */
             @JvmField
             public val DEFAULT: MaybeCreate = MaybeCreate(mode = Mode.DEFAULT_FILE)
 
             /**
              * Creates a new instance of [MaybeCreate] with provided [mode], or
-             * returns [DEFAULT] when [mode] == `664` or `null`.
+             * returns [DEFAULT] when [mode] == `666` or `null`.
              *
              * @param [mode] The permissions to use if the file is created.
              *
@@ -87,14 +87,14 @@ public sealed class OpenExcl private constructor(internal val _mode: Mode) {
         public companion object {
 
             /**
-             * The default [MustCreate] value with permissions `664`.
+             * The default [MustCreate] value with permissions `666`.
              * */
             @JvmField
             public val DEFAULT: MustCreate = MustCreate(mode = Mode.DEFAULT_FILE)
 
             /**
              * Creates a new instance of [MustCreate] with provided [mode], or
-             * returns [DEFAULT] when [mode] == `664` or `null`.
+             * returns [DEFAULT] when [mode] == `666` or `null`.
              *
              * @param [mode] The permissions to use when the file is created.
              *

--- a/library/file/src/commonMain/kotlin/io/matthewnelson/kmp/file/internal/-Mode.kt
+++ b/library/file/src/commonMain/kotlin/io/matthewnelson/kmp/file/internal/-Mode.kt
@@ -33,8 +33,8 @@ internal constructor(internal val value: String) {
     }
 
     internal companion object {
-        internal val DEFAULT_DIR = Mode("775")
-        internal val DEFAULT_FILE = Mode("664")
+        internal val DEFAULT_DIR = Mode("777")
+        internal val DEFAULT_FILE = Mode("666")
     }
 
     override fun toString(): String = value


### PR DESCRIPTION
Closes #182 