### PR TITLE
Change `AsyncFs.of` parameter `CoroutineContext` to also accept null

### DIFF
--- a/library/async/api/async.klib.api
+++ b/library/async/api/async.klib.api
@@ -40,7 +40,7 @@ open class io.matthewnelson.kmp.file.async/AsyncFs { // io.matthewnelson.kmp.fil
         final val Empty // io.matthewnelson.kmp.file.async/AsyncFs.Default.Empty|{}Empty[0]
             final fun <get-Empty>(): io.matthewnelson.kmp.file.async/AsyncFs // io.matthewnelson.kmp.file.async/AsyncFs.Default.Empty.<get-Empty>|<get-Empty>(){}[0]
 
-        final fun of(kotlin.coroutines/CoroutineContext): io.matthewnelson.kmp.file.async/AsyncFs // io.matthewnelson.kmp.file.async/AsyncFs.Default.of|of(kotlin.coroutines.CoroutineContext){}[0]
+        final fun of(kotlin.coroutines/CoroutineContext?): io.matthewnelson.kmp.file.async/AsyncFs // io.matthewnelson.kmp.file.async/AsyncFs.Default.of|of(kotlin.coroutines.CoroutineContext?){}[0]
         final fun toString(): kotlin/String // io.matthewnelson.kmp.file.async/AsyncFs.Default.toString|toString(){}[0]
     }
 

--- a/library/async/src/commonMain/kotlin/io/matthewnelson/kmp/file/async/AsyncFs.kt
+++ b/library/async/src/commonMain/kotlin/io/matthewnelson/kmp/file/async/AsyncFs.kt
@@ -62,11 +62,11 @@ public expect open class AsyncFs {
          *
          * @param [ctx] The [CoroutineContext]
          *
-         * @return An instance of [AsyncFs]. If provided [ctx] is equal to [Default.ctx],
+         * @return An instance of [AsyncFs]. If provided [ctx] is `null` or equal to [Default.ctx],
          *   then [Default] is returned. If provided [ctx] is [EmptyCoroutineContext], then
          *   [Empty] is returned.
          * */
-        public fun of(ctx: CoroutineContext): AsyncFs
+        public fun of(ctx: CoroutineContext?): AsyncFs
 
         /** @suppress */
         public override fun toString(): String

--- a/library/async/src/commonMain/kotlin/io/matthewnelson/kmp/file/async/internal/-CommonPlatform.kt
+++ b/library/async/src/commonMain/kotlin/io/matthewnelson/kmp/file/async/internal/-CommonPlatform.kt
@@ -26,10 +26,10 @@ import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.cancellation.CancellationException
 
 internal inline fun ((CoroutineContext) -> AsyncFs).commonOf(
-    ctx: CoroutineContext,
+    ctx: CoroutineContext?,
 ): AsyncFs = when (ctx) {
+    null, AsyncFs.Default.ctx -> AsyncFs.Default
     AsyncFs.Empty.ctx -> AsyncFs.Empty
-    AsyncFs.Default.ctx -> AsyncFs.Default
     else -> this(ctx)
 }
 

--- a/library/async/src/jsWasmJsMain/kotlin/io/matthewnelson/kmp/file/async/AsyncFs.kt
+++ b/library/async/src/jsWasmJsMain/kotlin/io/matthewnelson/kmp/file/async/AsyncFs.kt
@@ -39,7 +39,7 @@ public actual open class AsyncFs private constructor(public actual val ctx: Coro
 
         public actual val Empty: AsyncFs = AsyncFs(ctx = EmptyCoroutineContext)
 
-        public actual fun of(ctx: CoroutineContext): AsyncFs = ::AsyncFs.commonOf(ctx)
+        public actual fun of(ctx: CoroutineContext?): AsyncFs = ::AsyncFs.commonOf(ctx)
 
         /** @suppress */
         public actual override fun toString(): String = commonToString(isDefault = true)

--- a/library/async/src/jvmMain/kotlin/io/matthewnelson/kmp/file/async/AsyncFs.kt
+++ b/library/async/src/jvmMain/kotlin/io/matthewnelson/kmp/file/async/AsyncFs.kt
@@ -40,7 +40,7 @@ public actual open class AsyncFs private constructor(@JvmField public actual val
         public actual val Empty: AsyncFs = AsyncFs(ctx = EmptyCoroutineContext)
 
         @JvmStatic
-        public actual fun of(ctx: CoroutineContext): AsyncFs = ::AsyncFs.commonOf(ctx)
+        public actual fun of(ctx: CoroutineContext?): AsyncFs = ::AsyncFs.commonOf(ctx)
 
         /** @suppress */
         public actual override fun toString(): String = commonToString(isDefault = true)

--- a/library/async/src/nativeMain/kotlin/io/matthewnelson/kmp/file/async/AsyncFs.kt
+++ b/library/async/src/nativeMain/kotlin/io/matthewnelson/kmp/file/async/AsyncFs.kt
@@ -38,7 +38,7 @@ public actual open class AsyncFs private constructor(public actual val ctx: Coro
 
         public actual val Empty: AsyncFs = AsyncFs(ctx = EmptyCoroutineContext)
 
-        public actual fun of(ctx: CoroutineContext): AsyncFs = ::AsyncFs.commonOf(ctx)
+        public actual fun of(ctx: CoroutineContext?): AsyncFs = ::AsyncFs.commonOf(ctx)
 
         /** @suppress */
         public actual override fun toString(): String = commonToString(isDefault = true)


### PR DESCRIPTION
This PR adds ability to pass `null` as a parameter for `AsyncFs.of`, which will return `AsyncFs.Default`