### PR TITLE
Update `decodeBuffered` usage with new `throwOnOverflow` parameter of `true`

### DIFF
--- a/library/file/src/commonMain/kotlin/io/matthewnelson/kmp/file/KmpFile.kt
+++ b/library/file/src/commonMain/kotlin/io/matthewnelson/kmp/file/KmpFile.kt
@@ -18,7 +18,6 @@
 
 package io.matthewnelson.kmp.file
 
-import io.matthewnelson.encoding.core.Decoder.Companion.decodeBuffered
 import io.matthewnelson.kmp.file.internal.*
 import io.matthewnelson.kmp.file.internal.fs.*
 import kotlin.jvm.JvmField
@@ -664,9 +663,7 @@ public inline fun File.writeBytes(excl: OpenExcl?, array: ByteArray): File {
 @JvmName("writeUtf8To")
 @Throws(IOException::class)
 public fun File.writeUtf8(excl: OpenExcl?, appending: Boolean, text: String): File {
-    return commonWriteUtf8(excl, appending, text) { decoder, stream ->
-        decodeBuffered(decoder, action = stream::write)
-    }
+    return commonWriteUtf8(excl, appending, text)
 }
 
 /**

--- a/library/file/src/jsWasmJsMain/kotlin/io/matthewnelson/kmp/file/internal/async/-InteropAsyncFs.kt
+++ b/library/file/src/jsWasmJsMain/kotlin/io/matthewnelson/kmp/file/internal/async/-InteropAsyncFs.kt
@@ -242,10 +242,10 @@ public object InteropAsyncFs {
             _openWrite = { excl, appending ->
                 openWrite(this, excl, appending, createLock, suspendCancellable)
             },
-            _decodeBuffered = { decoder, stream ->
-                decodeBufferedAsync(decoder) { buf, offset, len ->
+            _decodeBuffered = { utf8, throwOnOverflow, stream ->
+                decodeBufferedAsync(decoder = utf8, throwOnOverflow, action = { buf, offset, len ->
                     (stream as InteropAsyncFileStream.Write)._writeAsync(buf, offset, len, suspendCancellable)
-                }
+                })
             },
         )
     }


### PR DESCRIPTION
This PR updates usage of `encoding` libs `decodeBuffered` function to express a `throwOnOverflow` of `true`.