### PR TITLE
Replace `FileStream` copy `Buffer` retention with `Buffer.allocUnsafe` on WasmJs

### DIFF
--- a/library/file/src/jsMain/kotlin/io/matthewnelson/kmp/file/internal/node/_ModuleBuffer.kt
+++ b/library/file/src/jsMain/kotlin/io/matthewnelson/kmp/file/internal/node/_ModuleBuffer.kt
@@ -33,7 +33,9 @@ internal actual sealed external class JsBuffer: JsUint8Array {
         // Always need to check for FsJsNode first
         @DelicateFileApi
         internal actual fun alloc(size: Double): JsBuffer
-
+        // Always need to check for FsJsNode first
+        @DelicateFileApi
+        internal actual fun allocUnsafe(size: Double): JsBuffer
         // Always need to check for FsJsNode first
         @DelicateFileApi
         internal fun isBuffer(any: dynamic): Boolean

--- a/library/file/src/jsWasmJsMain/kotlin/io/matthewnelson/kmp/file/internal/node/ModuleBuffer.kt
+++ b/library/file/src/jsWasmJsMain/kotlin/io/matthewnelson/kmp/file/internal/node/ModuleBuffer.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
-@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING", "PropertyName", "UNUSED")
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING", "NOTHING_TO_INLINE", "PropertyName", "UNUSED")
 
 package io.matthewnelson.kmp.file.internal.node
 
@@ -44,5 +44,8 @@ internal expect sealed class JsBuffer: JsUint8Array {
         // Always need to check for FsJsNode first
         @DelicateFileApi
         internal fun alloc(size: Double): JsBuffer
+        // Always need to check for FsJsNode first
+        @DelicateFileApi
+        internal fun allocUnsafe(size: Double): JsBuffer
     }
 }

--- a/library/file/src/jsWasmJsMain/kotlin/io/matthewnelson/kmp/file/internal/node/ModuleBuffer.kt
+++ b/library/file/src/jsWasmJsMain/kotlin/io/matthewnelson/kmp/file/internal/node/ModuleBuffer.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  **/
-@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING", "NOTHING_TO_INLINE", "PropertyName", "UNUSED")
+@file:Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING", "PropertyName", "UNUSED")
 
 package io.matthewnelson.kmp.file.internal.node
 

--- a/library/file/src/wasmJsMain/kotlin/io/matthewnelson/kmp/file/internal/node/JsNodeFileStream.kt
+++ b/library/file/src/wasmJsMain/kotlin/io/matthewnelson/kmp/file/internal/node/JsNodeFileStream.kt
@@ -19,7 +19,6 @@ package io.matthewnelson.kmp.file.internal.node
 
 import io.matthewnelson.encoding.core.EncoderDecoder.Companion.DEFAULT_BUFFER_SIZE
 import io.matthewnelson.kmp.file.DelicateFileApi
-import io.matthewnelson.kmp.file.IOException
 import io.matthewnelson.kmp.file.internal.async.SuspendCancellable
 import io.matthewnelson.kmp.file.internal.async.complete
 import io.matthewnelson.kmp.file.internal.async.withLockAsync
@@ -41,22 +40,14 @@ internal actual class JsNodeFileStream internal actual constructor(
     fs: ModuleFs,
 ): AbstractJsNodeFileStream(fd, canRead, canWrite, isAppending, fs, INIT) {
 
-    // Need to utilize a pool for copy buffers when reading/writing asynchronously
-    private var _asyncPool: ArrayDeque<JsBuffer>? = null
-    private val asyncPool: ArrayDeque<JsBuffer> get() = _asyncPool ?: run {
-        val pool = ArrayDeque<JsBuffer>(1)
-        _asyncPool = pool
-        pool
-    }
-
     @OptIn(ExperimentalContracts::class)
-    private inline fun <R> ArrayDeque<JsBuffer>.useBuffer(block: (jsBuf: JsBuffer) -> R): R {
+    private inline fun <R> withCopyBuffer(len: Int, block: (copyBuf: JsBuffer) -> R): R {
         contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }
-        val buf = removeFirstOrNull() ?: JsBuffer.alloc(DEFAULT_BUFFER_SIZE.toDouble())
+        val copyBuf = JsBuffer.allocUnsafe(size = maxOf(len, DEFAULT_BUFFER_SIZE).toDouble())
         try {
-            return block(buf)
+            return block(copyBuf)
         } finally {
-            if (isOpen() && size < 3) add(buf)
+            copyBuf.fill()
         }
     }
 
@@ -65,7 +56,6 @@ internal actual class JsNodeFileStream internal actual constructor(
         checkCanRead()
         return _positionLock.withTryLock {
             realRead(
-                syncBuf,
                 buf,
                 offset,
                 len,
@@ -82,7 +72,6 @@ internal actual class JsNodeFileStream internal actual constructor(
         checkCanRead()
         position.checkIsNotNegative()
         return realRead(
-            syncBuf,
             buf,
             offset,
             len,
@@ -102,22 +91,19 @@ internal actual class JsNodeFileStream internal actual constructor(
         checkIsOpen()
         checkCanRead()
         return _positionLock.withLockAsync {
-            asyncPool.useBuffer { jsBuf ->
-                realRead(
-                    jsBuf,
-                    buf,
-                    offset,
-                    len,
-                    -1L,
-                    _read = { fd, buffer, offset, len, position ->
-                        suspendCancellable { cont ->
-                            fs.read(fd, buffer, offset, len, position) { err, read, _ ->
-                                cont.complete(err) { read }
-                            }
-                        } as Double
-                    },
-                )
-            }
+            realRead(
+                buf,
+                offset,
+                len,
+                -1L,
+                _read = { fd, buffer, offset, len, position ->
+                    suspendCancellable { cont ->
+                        fs.read(fd, buffer, offset, len, position) { err, read, _ ->
+                            cont.complete(err) { read }
+                        }
+                    } as Double
+                },
+            )
         }
     }
 
@@ -131,27 +117,23 @@ internal actual class JsNodeFileStream internal actual constructor(
         checkIsOpen()
         checkCanRead()
         position.checkIsNotNegative()
-        return asyncPool.useBuffer { jsBuf ->
-            realRead(
-                jsBuf,
-                buf,
-                offset,
-                len,
-                position,
-                _read = { fd, buffer, offset, len, position ->
-                    suspendCancellable { cont ->
-                        fs.read(fd, buffer, offset, len, position) { err, read, _ ->
-                            cont.complete(err) { read }
-                        }
-                    } as Double
-                },
-            )
-        }
+        return realRead(
+            buf,
+            offset,
+            len,
+            position,
+            _read = { fd, buffer, offset, len, position ->
+                suspendCancellable { cont ->
+                    fs.read(fd, buffer, offset, len, position) { err, read, _ ->
+                        cont.complete(err) { read }
+                    }
+                } as Double
+            },
+        )
     }
 
     @OptIn(ExperimentalContracts::class)
     private inline fun realRead(
-        copyBuf: JsBuffer,
         buf: ByteArray,
         offset: Int,
         len: Int,
@@ -163,39 +145,41 @@ internal actual class JsNodeFileStream internal actual constructor(
         }
         buf.checkBounds(offset, len)
 
-        var pos = offset
-        var total = 0
-        while (total < len) {
-            val length = minOf(copyBuf.length.toInt(), len - total)
-            val position = if (p == -1L) _position else (p + total.toLong())
-            val fd = delegateOrClosed(isWrite = false, total) { fdOrClosed() }
-            val read = try {
-                _read(
-                    fd,
-                    copyBuf,
-                    0.toDouble(),
-                    length.toDouble(),
-                    position.toDouble(),
-                )
-            } catch (t: Throwable) {
-                if (t is CancellationException) throw t
-                throw t.toIOException().toMaybeInterruptedIOException(isWrite = false, total)
-            }.toInt()
+        withCopyBuffer(len) { copyBuf ->
+            var pos = offset
+            var total = 0
+            while (total < len) {
+                val length = minOf(copyBuf.length.toInt(), len - total)
+                val position = if (p == -1L) _position else (p + total.toLong())
+                val fd = delegateOrClosed(isWrite = false, total) { fdOrClosed() }
+                val read = try {
+                    _read(
+                        fd,
+                        copyBuf,
+                        0.toDouble(),
+                        length.toDouble(),
+                        position.toDouble(),
+                    )
+                } catch (t: Throwable) {
+                    if (t is CancellationException) throw t
+                    throw t.toIOException().toMaybeInterruptedIOException(isWrite = false, total)
+                }.toInt()
 
-            if (read <= 0) {
-                if (total == 0) total = -1
-                break
+                if (read <= 0) {
+                    if (total == 0) total = -1
+                    break
+                }
+
+                for (i in 0 until read) {
+                    buf[pos++] = copyBuf.readInt8(i.toDouble())
+                }
+
+                total += read
+                if (p == -1L) _position += read
             }
 
-            for (i in 0 until read) {
-                buf[pos++] = copyBuf.readInt8(i.toDouble())
-            }
-
-            total += read
-            if (p == -1L) _position += read
+            return total
         }
-
-        return total
     }
 
     actual override fun write(buf: ByteArray, offset: Int, len: Int) {
@@ -203,7 +187,6 @@ internal actual class JsNodeFileStream internal actual constructor(
         checkCanWrite()
         _positionLock.withTryLock {
             realWrite(
-                syncBuf,
                 buf,
                 offset,
                 len,
@@ -221,7 +204,6 @@ internal actual class JsNodeFileStream internal actual constructor(
         checkCanWrite()
         position.checkIsNotNegative()
         realWrite(
-            syncBuf,
             buf,
             offset,
             len,
@@ -242,23 +224,20 @@ internal actual class JsNodeFileStream internal actual constructor(
         checkIsOpen()
         checkCanWrite()
         _positionLock.withLockAsync {
-            asyncPool.useBuffer { jsBuf ->
-                realWrite(
-                    jsBuf,
-                    buf,
-                    offset,
-                    len,
-                    -1L,
-                    _size = { _sizeAsync(suspendCancellable) },
-                    _write = { fd, buffer, offset, len, position ->
-                        suspendCancellable { cont ->
-                            fs.write(fd, buffer, offset, len, position) { err, write, _ ->
-                                cont.complete(err) { write }
-                            }
-                        } as Double
-                    },
-                )
-            }
+            realWrite(
+                buf,
+                offset,
+                len,
+                -1L,
+                _size = { _sizeAsync(suspendCancellable) },
+                _write = { fd, buffer, offset, len, position ->
+                    suspendCancellable { cont ->
+                        fs.write(fd, buffer, offset, len, position) { err, write, _ ->
+                            cont.complete(err) { write }
+                        }
+                    } as Double
+                },
+            )
         }
     }
 
@@ -272,28 +251,24 @@ internal actual class JsNodeFileStream internal actual constructor(
         checkIsOpen()
         checkCanWrite()
         position.checkIsNotNegative()
-        asyncPool.useBuffer { jsBuf ->
-            realWrite(
-                jsBuf,
-                buf,
-                offset,
-                len,
-                position,
-                _size = { _sizeAsync(suspendCancellable) },
-                _write = { fd, buffer, offset, len, position ->
-                    suspendCancellable { cont ->
-                        fs.write(fd, buffer, offset, len, position) { err, write, _ ->
-                            cont.complete(err) { write }
-                        }
-                    } as Double
-                },
-            )
-        }
+        realWrite(
+            buf,
+            offset,
+            len,
+            position,
+            _size = { _sizeAsync(suspendCancellable) },
+            _write = { fd, buffer, offset, len, position ->
+                suspendCancellable { cont ->
+                    fs.write(fd, buffer, offset, len, position) { err, write, _ ->
+                        cont.complete(err) { write }
+                    }
+                } as Double
+            },
+        )
     }
 
     @OptIn(ExperimentalContracts::class)
     private inline fun realWrite(
-        copyBuf: JsBuffer,
         buf: ByteArray,
         offset: Int,
         len: Int,
@@ -309,53 +284,34 @@ internal actual class JsNodeFileStream internal actual constructor(
 
         if (p == -1L && isAppending) _position = _size()
 
-        var pos = offset
-        var total = 0
-        while (total < len) {
-            val length = minOf(copyBuf.length.toInt(), len - total)
+        withCopyBuffer(len) { copyBuf ->
+            var pos = offset
+            var total = 0
+            while (total < len) {
+                val length = minOf(copyBuf.length.toInt(), len - total)
 
-            for (i in 0 until length) {
-                copyBuf.writeInt8(buf[pos++], i.toDouble())
+                for (i in 0 until length) {
+                    copyBuf.writeInt8(buf[pos++], i.toDouble())
+                }
+
+                val position = if (p == -1L) _position else p + total
+                val fd = delegateOrClosed(isWrite = true, total) { fdOrClosed() }
+                val write = try {
+                    _write(
+                        fd,
+                        copyBuf,
+                        0.toDouble(),
+                        length.toDouble(),
+                        position.toDouble(),
+                    )
+                } catch (t: Throwable) {
+                    if (t is CancellationException) throw t
+                    throw t.toIOException().toMaybeInterruptedIOException(isWrite = true, total)
+                }.toInt()
+
+                total += write
+                if (p == -1L) _position += write
             }
-
-            val position = if (p == -1L) _position else p + total
-            val fd = delegateOrClosed(isWrite = true, total) { fdOrClosed() }
-            val write = try {
-                _write(
-                    fd,
-                    copyBuf,
-                    0.toDouble(),
-                    length.toDouble(),
-                    position.toDouble(),
-                )
-            } catch (t: Throwable) {
-                if (t is CancellationException) throw t
-                throw t.toIOException().toMaybeInterruptedIOException(isWrite = true, total)
-            }.toInt()
-
-            total += write
-            if (p == -1L) _position += write
-        }
-    }
-
-    override fun closeFinally(t: IOException?) {
-        _asyncPool?.clear()
-        _asyncPool = null
-    }
-
-    private companion object {
-
-        private var _syncBuf: JsBuffer? = null
-
-        // Node is single threaded and the API is synchronous such that a single
-        // copy buffer can be used for all synchronous read/write operations.
-        //
-        // Until Kotlin provides better interop between wasmJs and ByteArray,
-        // we are left copying bytes to/from a buffer.
-        private val syncBuf: JsBuffer get() = _syncBuf ?: run {
-            val buf = JsBuffer.alloc((DEFAULT_BUFFER_SIZE * 2).toDouble())
-            _syncBuf = buf
-            buf
         }
     }
 }

--- a/library/file/src/wasmJsMain/kotlin/io/matthewnelson/kmp/file/internal/node/_ModuleBuffer.kt
+++ b/library/file/src/wasmJsMain/kotlin/io/matthewnelson/kmp/file/internal/node/_ModuleBuffer.kt
@@ -33,7 +33,9 @@ internal actual sealed external class JsBuffer: JsUint8Array {
         // Always need to check for FsJsNode first
         @DelicateFileApi
         internal actual fun alloc(size: Double): JsBuffer
-
+        // Always need to check for FsJsNode first
+        @DelicateFileApi
+        internal actual fun allocUnsafe(size: Double): JsBuffer
         // Always need to check for FsJsNode first
         @DelicateFileApi
         internal fun isBuffer(any: JsAny?): Boolean


### PR DESCRIPTION
Closes #227 